### PR TITLE
Add OSX Support to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
 CC = gcc
 CFLAGS = -I. -Wall
-LIBS =  -lncursesw
+
+OS = $(shell uname -s)
+
+ifeq ($(OS), Darwin)
+# OSX Flags (using Homebrew ncurses)
+LIBS += -L/usr/local/opt/ncurses/lib
+CFLAGS += -I/usr/local/opt/ncurses/include
+LIBS += -lncurses
+endif
+
+ifeq ($(OS), Linux)
+LIBS += -lncursesw
+endif
+
 SRCS = pxlart.c
 OBJS = $(SRCS: .c = .o)
 PROG = pxlart


### PR DESCRIPTION
Managed to get pxlart to build on OSX via Homebrew ncurses. The changes in the Makefile will check the operating system using `uname -s`, and will set the build flags accordingly. More details are in the commit message.